### PR TITLE
feat: ✨  이메일, 추가정보 입력 페이지 로직 구현 (#20)

### DIFF
--- a/db.json
+++ b/db.json
@@ -2,9 +2,9 @@
   "users": [
     {
       "email": "test@test.com",
-      "password": "123456",
-      "nickname": "test",
-      "birth": "1996.02.09"
+      "password": "$2b$12$U9nfyOuJTxpwJlZenWvlRelLEpDsrHUv7z06BTx7xb1PwowHiVfHi",
+      "nickname": "abc",
+      "birth": "2022.01.01"
     }
   ]
 }

--- a/public/js/constant.js
+++ b/public/js/constant.js
@@ -2,3 +2,5 @@ export const PHONE_NUMBER_LENGTH = 13;
 export const VERIFIED_CODE_LENGTH = 4;
 
 export const SECOND_MILLISECOND = 1000;
+
+export const PASSWORD_MIN_LENGTH = 10;

--- a/public/js/signup-detail.js
+++ b/public/js/signup-detail.js
@@ -1,0 +1,180 @@
+import { PASSWORD_MIN_LENGTH } from './constant.js';
+
+const init = () => {
+  const $signupForm = document.querySelector('.singup-detail-form');
+  const $emailGroup = document.querySelector('.singup-detail-group.email');
+  const $emailInput = document.querySelector('.singup-detail-group.email .signup-input');
+  const $emailError = document.querySelector('.singup-detail-group.email p.error-message');
+  const $emailRemoveButton = document.querySelector('.signup-detail-input-remover');
+  const $emailDuplicateButton = document.querySelector('.singup-email-duplicate-button');
+
+  const $nicknameInput = document.querySelector('.singup-detail-group.nickname .signup-input');
+  const $nicknameError = document.querySelector('.singup-detail-group.nickname p.error-message');
+
+  const $passwordInput = document.querySelector('.singup-detail-group.password .signup-input');
+  const $passwordError = document.querySelector('.singup-detail-group.password p.error-message');
+
+  const $birthInput = document.querySelector('.singup-detail-group.birth .signup-input');
+  const $birthError = document.querySelector('.singup-detail-group.birth p.error-message');
+
+  const $nextButton = document.querySelector('#signup-detail-next-page');
+
+  const removeInputValue = ($input, $removeButton) => {
+    $input.value = '';
+    $removeButton.classList.add('hide');
+  };
+
+  const showErrorMessage = ($target) => {
+    $target.classList.remove('hide');
+  };
+
+  const hideErrorMessage = ($target) => {
+    $target.classList.add('hide');
+  };
+
+  const verifyInputValue = ($target, isValid) => {
+    if (isValid) $target.classList.add('verified');
+    else $target.classList.remove('verified');
+  };
+
+  const validateEmail = (value) => {
+    const emailRegExp = /^[a-zA-Z0-9+-_.]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$/;
+    return emailRegExp.test(value);
+  };
+
+  const validatePassword = (value) => {
+    if (value.length < PASSWORD_MIN_LENGTH) return false;
+
+    let regCheckCount = 0;
+
+    const engUpperCaseRegExp = /[A-Z]/g;
+    const engLowerCaseRegExp = /[a-z]/g;
+    const numberRegExp = /[0-9]/g;
+    const specialRegExp = /[`~!@#$%^&*|\\\'\";:\/?]/g;
+
+    if (engUpperCaseRegExp.test(value)) regCheckCount += 1;
+    if (engLowerCaseRegExp.test(value)) regCheckCount += 1;
+    if (numberRegExp.test(value)) regCheckCount += 1;
+    if (specialRegExp.test(value)) regCheckCount += 1;
+
+    if (regCheckCount < 2) return false;
+
+    const sameNumberRegExp = /([0-9])\1\1/g;
+    const continuousNumberRegExp = /012|123|234|345|456|567|678|789|987|876|765|654|543|432|321|210/g;
+
+    if (sameNumberRegExp.test(value) || continuousNumberRegExp.test(value)) return false;
+
+    return true;
+  };
+
+  const validateBirth = (value) => {
+    const birthRegExp = /^(19[0-9][0-9]|20\d{2}).(0[0-9]|1[0-2]).(0[1-9]|[1-2][0-9]|3[0-1])$/;
+
+    return birthRegExp.test(value);
+  };
+
+  const setAutoDot = ($target, value) => {
+    $target.value = value.replace(/[^0-9]/g, '').replace(/^(\d{4})(\d{2})(\d{2})$/, `$1.$2.$3`);
+  };
+
+  const verifyAllRequiredInputs = () => {
+    const inputCount = document.querySelectorAll('.signup-input').length;
+    const verifiedInputCount = document.querySelectorAll('.signup-input.verified').length;
+    return inputCount === verifiedInputCount;
+  };
+
+  const activeNextButton = () => {
+    $nextButton.classList.add('verified');
+  };
+
+  const checkForm = () => {
+    if (!verifyAllRequiredInputs()) return;
+
+    activeNextButton();
+  };
+
+  const clickEmailDuplicateButton = () => {
+    const emailValue = $emailInput.value;
+
+    verifyInputValue($emailInput, validateEmail(emailValue));
+
+    if (validateEmail(emailValue)) {
+      $emailGroup.classList.add('verified');
+      $emailInput.disabled = true;
+      $emailRemoveButton.classList.add('hide');
+    } else {
+      showErrorMessage($emailError);
+    }
+  };
+
+  const changeEmailInput = (e) => {
+    const { value } = e.target;
+
+    if (value) $emailRemoveButton.classList.remove('hide');
+    else $emailRemoveButton.classList.add('hide');
+
+    if (!$emailError.classList.contains('hide')) hideErrorMessage($emailError);
+  };
+
+  const changeNicknameInput = (e) => {
+    const { value } = e.target;
+
+    verifyInputValue($nicknameInput, !!value);
+
+    if (!value) showErrorMessage($nicknameError);
+    else hideErrorMessage($nicknameError);
+
+    checkForm();
+  };
+
+  const changePasswordInput = (e) => {
+    const { value } = e.target;
+
+    verifyInputValue($passwordInput, validatePassword(value));
+
+    if (!validatePassword(value)) showErrorMessage($passwordError);
+    else hideErrorMessage($passwordError);
+
+    checkForm();
+  };
+
+  const clickEmailRemoveButton = () => {
+    removeInputValue($emailInput, $emailRemoveButton);
+  };
+
+  const changeBirthInput = (e) => {
+    const { value } = e.target;
+
+    setAutoDot($birthInput, value);
+
+    verifyInputValue($birthInput, validateBirth($birthInput.value));
+
+    if (!validateBirth($birthInput.value)) showErrorMessage($birthError);
+    else hideErrorMessage($birthError);
+
+    checkForm();
+  };
+
+  const clickNextButton = () => {
+    if (!$nextButton.classList.contains('verified')) return;
+
+    $emailInput.disabled = false;
+    $signupForm.submit();
+  };
+
+  const submitForm = (e) => {
+    e.preventDefault();
+    console.log(e.target.value);
+  };
+
+  $emailInput.addEventListener('input', changeEmailInput);
+  $emailDuplicateButton.addEventListener('click', clickEmailDuplicateButton);
+  $emailRemoveButton.addEventListener('click', clickEmailRemoveButton);
+  $nicknameInput.addEventListener('input', changeNicknameInput);
+  $passwordInput.addEventListener('input', changePasswordInput);
+  $birthInput.addEventListener('input', changeBirthInput);
+  $nextButton.addEventListener('click', clickNextButton);
+  $signupForm.addEventListener('submit', submitForm);
+};
+
+init();

--- a/public/js/signup-phone.js
+++ b/public/js/signup-phone.js
@@ -21,14 +21,14 @@ const init = () => {
     return randomCode;
   };
 
-  const setAutoHyphen = ($input) => {
-    $input.value = $input.value.replace(/[^0-9]/g, '').replace(/^(\d{2,3})(\d{3,4})(\d{4})$/, `$1-$2-$3`);
+  const setAutoHyphen = ($target, value) => {
+    $target.value = value.replace(/[^0-9]/g, '').replace(/^(\d{2,3})(\d{3,4})(\d{4})$/, `$1-$2-$3`);
   };
 
-  const validatePhoneNumber = ($input) => {
+  const validatePhoneNumber = (value) => {
     const phoneRegExp = /01[0-9]{1}-[0-9]{4}-[0-9]{4}/;
 
-    return phoneRegExp.test($input.value);
+    return phoneRegExp.test(value);
   };
 
   const removePhoneInputValue = () => {
@@ -66,6 +66,7 @@ const init = () => {
     $phoneLabel.classList.add('verified');
     $validateButton.classList.add('hide');
     $verifiedCodeForm.classList.remove('hide');
+    $phoneInputRemoveButton.classList.add('hide');
 
     $phoneInput.disabled = true;
 
@@ -73,12 +74,14 @@ const init = () => {
     setVerifiedCode(randomCode);
   };
 
-  const changePhoneInput = () => {
-    setAutoHyphen($phoneInput);
-    toggleShowPhoneInputRemoveButton();
+  const changePhoneInput = (e) => {
+    const { value } = e.target;
 
+    setAutoHyphen($phoneInput, value);
+
+    toggleShowPhoneInputRemoveButton();
     if ($phoneInput.value.length === PHONE_NUMBER_LENGTH) {
-      if (validatePhoneNumber($phoneInput)) {
+      if (validatePhoneNumber($phoneInput.value)) {
         $phoneValidateCheck.classList.add('verified');
         return;
       }
@@ -92,8 +95,10 @@ const init = () => {
     setVerifiedCode(randomCode);
   };
 
-  const changeVerifiedCodeInput = () => {
-    if ($verifiedCodeInput.value.length === VERIFIED_CODE_LENGTH) {
+  const changeVerifiedCodeInput = (e) => {
+    const { value } = e.target;
+
+    if (value.length === VERIFIED_CODE_LENGTH) {
       $nextPageButton.classList.add('verified');
       return;
     }

--- a/public/styles/signup-detail.css
+++ b/public/styles/signup-detail.css
@@ -1,9 +1,17 @@
+.error-message {
+  position: absolute;
+
+  left: 0;
+  bottom: -20px;
+  margin-top: 4px;
+}
+
 .signup-detail-next-page {
   cursor: default;
   color: var(--color-gray300);
 }
 
-.signup-detail-next-page.active {
+.signup-detail-next-page.verified {
   cursor: pointer;
   color: var(--color-black);
 }
@@ -25,13 +33,25 @@
   font-size: 14px;
 }
 
-.signup-email-form {
+.singup-detail-group {
   margin-bottom: 50px;
 }
 
-.signup-email-input-wrapper {
+.signup-detail-input-wrapper {
   display: flex;
+
   gap: 8px;
+}
+
+.signup-input-wrapper {
+  position: relative;
+
+  flex: 1;
+  display: flex;
+}
+
+.signup-input-wrapper input {
+  width: 100%;
 }
 
 .signup-input-wrapper {
@@ -58,4 +78,23 @@
 
   background: url('/assets/icons/check-inactive.png');
   background-size: cover;
+}
+
+.signup-input.verified + .signup-detail-input-check {
+  background: url('/assets/icons/check-active.png');
+  background-size: cover;
+}
+
+.signup-detail-input-remover {
+  position: absolute;
+  right: 30px;
+  bottom: 10px;
+}
+
+.singup-detail-group:not(.email) {
+  display: none;
+}
+
+.singup-detail-group.email.verified ~ .singup-detail-group {
+  display: block;
 }

--- a/public/styles/signup-phone.css
+++ b/public/styles/signup-phone.css
@@ -3,7 +3,7 @@
   color: var(--color-gray300);
 }
 
-.signup-phone-next-page.active {
+.signup-phone-next-page.verified {
   cursor: pointer;
   color: var(--color-black);
 }
@@ -58,19 +58,6 @@
   position: absolute;
   bottom: 10px;
   right: 30px;
-
-  background: transparent;
-  width: 14px;
-  height: 14px;
-}
-
-.signup-phone-input-remover {
-  display: none;
-}
-
-.signup-phone-input-remover img {
-  width: 14px;
-  height: 14px;
 }
 
 .signup-phone-verified-form {
@@ -85,9 +72,4 @@
 
   font-size: 14px;
   color: var(--color-primary);
-}
-
-.signup-phone-next-page.verified {
-  cursor: pointer;
-  color: var(--color-black);
 }

--- a/public/styles/styles.css
+++ b/public/styles/styles.css
@@ -77,7 +77,7 @@ button {
 }
 
 .error-message {
-  font-size: 12px;
+  font-size: 10px;
 
   color: var(--color-red);
 }
@@ -168,6 +168,7 @@ input[type='radio'] + label {
   -moz-user-select: none;
   -ms-user-select: none;
 }
+
 input[type='radio'] + label i {
   display: inline-block;
 
@@ -205,4 +206,15 @@ input[type='radio']:checked + label i {
 
   width: 60px;
   height: auto;
+}
+
+.input-remover-button {
+  background: transparent;
+  width: 14px;
+  height: 14px;
+}
+
+.input-remover-button img {
+  width: 14px;
+  height: 14px;
 }

--- a/routes/user.js
+++ b/routes/user.js
@@ -24,6 +24,7 @@ router.post('/signin', async (req, res) => {
 });
 
 router.post('/signup', async (req, res) => {
+  console.log(req.body);
   const { email, password, nickname, birth } = req.body;
 
   const hashedPassword = await bcrypt.hash(password, 12);
@@ -36,8 +37,7 @@ router.post('/signup', async (req, res) => {
   };
 
   db.get('users').push(user).write();
-
-  res.render('pages/auth/signin');
+  res.redirect('/signin');
 });
 
 module.exports = router;

--- a/views/pages/auth/signup-detail.pug
+++ b/views/pages/auth/signup-detail.pug
@@ -14,42 +14,64 @@ block next-page
 
 block content
   .signup-detail-wrapper
-    form#signup-email-form.signup-email-form
-      label.signup-detail-label(for='signup-email') 이메일
-      .signup-email-input-wrapper
-        input.signup-detail-input.input-underline(type='text', placeholder='ex) crong@codesquad.kr', required)
-        button#signup-email-input-remover.signup-detail-input-remover.hide(type='button')
-          img(src='/assets/icons/close-circle.png', alt='이메일 지우기')
+    form.singup-detail-form(action='/user/signup', method='POST')
+      .singup-detail-group.email
+        label.signup-detail-label 이메일
+        .signup-detail-input-wrapper
+          .signup-input-wrapper
+            input.signup-input.input-underline(
+              type='text',
+              name='email',
+              placeholder='ex) crong@woowahan.com',
+              required
+            )
+            .signup-detail-input-check
+            p.error-message.hide 이메일 형식을 지켜주세요.
+            button.signup-detail-input-remover.input-remover-button.hide(type='button')
+              img(src='/assets/icons/close-circle.png', alt='번호 지우기')
 
-        +button("중복확인","#ffffff", "#000000", "#bbbbbb").singup-email-duplicate-button
+          +button('중복확인', "#ffffff", "#bbbbbb", "#bbbbbb").singup-email-duplicate-button(type='button')
 
-    .signup-detail-info-wrapper
-      div
-        label.signup-detail-label(for='signup-nickname') 닉네임
-        .signup-input-wrapper
-          input#signup-nickname-input.signup-detail-input.input-underline.w-full(
-            type='text',
-            placeholder='닉네임을 입력해주세요.',
-            required
-          )
-          .signup-detail-input-check
-      div
-        label.signup-detail-label(for='signup-password') 비밀번호
-        .signup-input-wrapper
-          input#signup-password-input.signup-detail-input.input-underline.w-full(
-            type='text',
-            placeholder='10자 이상 대문자, 소문자, 숫자, 특수문자 중 2종류 조합',
-            required
-          )
-          .signup-detail-input-check
-      div
-        label.signup-detail-label(for='signup-password') 생년월일
-        .signup-input-wrapper
-          input#signup-password-input.signup-detail-input.input-underline.w-full(
-            type='text',
-            placeholder='예) 2000.01.01',
-            required
-          )
-          .signup-detail-input-check
+      .singup-detail-group.nickname
+        label.signup-detail-label 닉네임
+        .signup-detail-input-wrapper
+          .signup-input-wrapper
+            input.signup-input.input-underline(type='text', name='nickname', placeholder='닉네임을 입력해주세요.', required)
+            .signup-detail-input-check
+            p.error-message.hide 닉네임을 입력해주세요.
+            button.signup-detail-input-remover.input-remover-button.hide(type='button')
+              img(src='/assets/icons/close-circle.png', alt='번호 지우기')
+
+      .singup-detail-group.password
+        label.signup-detail-label 비밀번호
+        .signup-detail-input-wrapper
+          .signup-input-wrapper
+            input.signup-input.input-underline(
+              type='password',
+              name='password',
+              placeholder='10자 이상 영어 대문자, 소문자, 숫자 특수문자 2종류',
+              required
+            )
+            .signup-detail-input-check
+            p.error-message.hide 10자 이상 영어 대문자, 소문자, 숫자 특수문자 중 2종류를 조합해야 합니다.
+            button.signup-detail-input-remover.input-remover-button.hide(type='button')
+              img(src='/assets/icons/close-circle.png', alt='번호 지우기')
+
+      .singup-detail-group.birth
+        label.signup-detail-label 생년월일
+        .signup-detail-input-wrapper
+          .signup-input-wrapper
+            input.signup-input.input-underline(
+              type='text',
+              name='birth',
+              placeholder='ex) 2000.01.01',
+              maxLength='10',
+              required
+            )
+            .signup-detail-input-check
+            p.error-message.hide 생년월일을 제대로 입력해주세요.
+            button.signup-detail-input-remover.input-remover-button.hide(type='button')
+              img(src='/assets/icons/close-circle.png', alt='번호 지우기')
 
 block script
+  script(src='/js/signup-detail.js', type='module')

--- a/views/pages/auth/signup-phone.pug
+++ b/views/pages/auth/signup-phone.pug
@@ -25,7 +25,7 @@ block content
           maxlength='13',
           required
         )
-        button#signup-phone-input-remover.signup-phone-input-remover.hide(type='button')
+        button#signup-phone-input-remover.signup-phone-input-remover.input-remover-button.hide(type='button')
           img(src='/assets/icons/close-circle.png', alt='번호 지우기')
         #signup-phone-verified-check.signup-phone-verified-check
 


### PR DESCRIPTION
## 📑 개요

추가정보 입력 페이지 로직 구현 

## 📎 관련 이슈

[회원가입 - 이메일, 추가정보 입력 페이지 로직 구현 (#20)] [#20]

## 💬 작업 내용

- 이메일 중복확인 클릭 시, 'v' 체크 완료 표시 노출되고 닉네임, 비밀번호, 생년월일 입력 UI 노출 
  - 이메일 검증 ('@' , '.')
- 비밀번호 규칙 10자 이상, 대문자, 소문자, 숫자, 특수문자 - 2종류 조합
- 같은 숫자 혹은 연속된 숫자 3개 이상 입력 불가능
- 생년월일 입력 시, 자동으로 (.)이 표시 된다.
  - 올바르지 않은 생년월일 입력시 오류 메시지 노출 
- 모든 값 정상적으로 입력될 경우 '완료' 표시 활성화되고, 로그인 페이지로 이동

## 🚧 PR 특이 사항

Form POST 요청 시, input이 `disabled` 이면 값이 전송 안되는걸 몰라서 시간을 많이 썼습니다...
이메일 중복확인 후, 수정 못하게 하려고 해놓았는데 여기서 많이 헤맸지만 덕분에 기억에 잘 남을 것 같습니다.

리팩토링이 필요한 부분이 눈에 많이 보임..

남은 시간동안 리팩토링 하겠습니다.